### PR TITLE
Add reset parameter and pattern matching to log_with_tag

### DIFF
--- a/logger/xp.py
+++ b/logger/xp.py
@@ -2,6 +2,7 @@ import git
 import time
 import json
 import sys
+import fnmatch
 
 from builtins import dict
 from collections import defaultdict, OrderedDict
@@ -144,14 +145,25 @@ class Experiment(object):
         if to_visdom and self.use_visdom:
             self.plotter.plot_config(config_dict)
 
-    def log_with_tag(self, tag, idx=None):
+    def log_with_tag(self, pattern, idx=None, reset=False):
+        """ Log metrics from each tag matching the given pattern.
+        Pattern parameter must be in Unix shell-style wildcards format.
+        """
+        # log metrics of all tags matching the given pattern
+        for tag in fnmatch.filter(self.metrics, pattern):
+            self._log_with_tag(tag, idx, reset)
+
+    def _log_with_tag(self, tag, idx=None, reset=False):
 
         # log all metrics with given tag except Parents
         # (to avoid logging twice the information)
         for metric in self.metrics[tag].values():
             if isinstance(metric, ParentWrapper_):
                 continue
-            self.log_metric(metric, idx)
+            if reset:
+                self.log_and_reset_metric(metric, idx)
+            else:
+                self.log_metric(metric, idx)
 
     def log_metric(self, metric, idx=None):
 


### PR DESCRIPTION
Implementation of #8 .
Allow to log several/all tags at once, add `reset` parameter to `log_with_tag` and update tests.
