### PR TITLE
Replacing deprecated viz.updateTrace()

### DIFF
--- a/logger/plotter.py
+++ b/logger/plotter.py
@@ -78,9 +78,10 @@ class Plotter(object):
             self.windows[name] = self.viz.line(Y=y, X=x, opts=opts)
             return True
         else:
-            return bool(self.viz.updateTrace(Y=y, X=x, name=tag,
-                                             win=self.windows[name],
-                                             append=True))
+            return bool(self.viz.line(Y=y, X=x, name=tag,
+                                      win=self.windows[name],
+                                      update='append'))
+
 
     def plot_xp(self, xp):
 


### PR DESCRIPTION
Visdoms updateTrace() is deprecated. 
See https://github.com/facebookresearch/visdom/commit/5e1a28f740741ad265beb9fff00127631fbe6e11

To make the logger work with newer visdom versions, I replaced the call to `viz.updateTrace()` with a call to 

`viz.line(..., update='append')`